### PR TITLE
Feature/add left label

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.13.4)
+  - MessageKit (1.0.0-beta.1)
 
 DEPENDENCIES:
   - MessageKit (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  MessageKit: f51122543e9ba8b521e5eab58b0385bd7ce47a10
+  MessageKit: f7439b37af9c4bccd907fb3db01d96fd892c3c82
 
 PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -285,6 +285,14 @@ extension ConversationViewController: MessagesDataSource {
 
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
 
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        let dateString = formatter.string(from: message.sentDate)
+        return NSAttributedString(string: dateString, attributes: [NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .caption2)])
+    }
+
+    func messageTrailingLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        formatter.dateFormat = "HH:mm"
         let dateString = formatter.string(from: message.sentDate)
         return NSAttributedString(string: dateString, attributes: [NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .caption2)])
     }
@@ -371,6 +379,10 @@ extension ConversationViewController: MessagesLayoutDelegate {
 
     func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         return 16
+    }
+
+    func messageTrailingLabelWidth(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 34
     }
 
 }

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -46,7 +46,11 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
     public var messageBottomLabelAlignment = LabelAlignment(textAlignment: .center, textInsets: .zero)
     public var messageBottomLabelSize: CGSize = .zero
 
-    // MARK: - Methods
+    public var messageTrailingLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: .zero)
+    public var messageTrailingLabelSize: CGSize = .zero
+    public var messageTrailingPosition: TrailingLabelPosition = TrailingLabelPosition(vertical: .messageBottom)
+
+    // MARK: - Methods 
 
     open override func copy(with zone: NSZone? = nil) -> Any {
         // swiftlint:disable force_cast
@@ -63,6 +67,10 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
         copy.messageTopLabelSize = messageTopLabelSize
         copy.messageBottomLabelAlignment = messageBottomLabelAlignment
         copy.messageBottomLabelSize = messageBottomLabelSize
+        copy.messageTrailingLabelAlignment = messageTrailingLabelAlignment
+        copy.messageTrailingLabelSize = messageTrailingLabelSize
+        copy.messageTrailingPosition = messageTrailingPosition
+
         return copy
         // swiftlint:enable force_cast
     }
@@ -82,6 +90,9 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
                 && attributes.messageTopLabelSize == messageTopLabelSize
                 && attributes.messageBottomLabelAlignment == messageBottomLabelAlignment
                 && attributes.messageBottomLabelSize == messageBottomLabelSize
+                && attributes.messageTrailingPosition == messageTrailingPosition
+                && attributes.messageTrailingLabelAlignment == messageTrailingLabelAlignment
+                && attributes.messageTrailingLabelSize == messageTrailingLabelSize
         } else {
             return false
         }

--- a/Sources/Models/AvatarPosition.swift
+++ b/Sources/Models/AvatarPosition.swift
@@ -24,10 +24,12 @@
 
 import Foundation
 
+public typealias TrailingLabelPosition = AvatarPosition
+
 /// Used to determine the `Horizontal` and `Vertical` position of
 // an `AvatarView` in a `MessageCollectionViewCell`.
 public struct AvatarPosition {
-    
+
     /// An enum representing the horizontal alignment of an `AvatarView`.
     public enum Horizontal {
         

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -78,6 +78,16 @@ public protocol MessageCellDelegate: MessageLabelDelegate {
     /// method `messageForItem(at:indexPath:messagesCollectionView)`.
     func didTapMessageBottomLabel(in cell: MessageCollectionViewCell)
 
+    /// Triggered when a tap occurs in the messageTrailingLabel.
+    ///
+    /// - Parameters:
+    ///   - cell: The cell tap the touch occurred.
+    ///
+    /// You can get a reference to the `MessageType` for the cell by using `UICollectionView`'s
+    /// `indexPath(for: cell)` method. Then using the returned `IndexPath` with the `MessagesDataSource`
+    /// method `messageForItem(at:indexPath:messagesCollectionView)`.
+    func didTapMessageTrailingLabel(in cell: MessageCollectionViewCell)
+
 }
 
 public extension MessageCellDelegate {
@@ -91,4 +101,6 @@ public extension MessageCellDelegate {
     func didTapMessageTopLabel(in cell: MessageCollectionViewCell) {}
 
     func didTapMessageBottomLabel(in cell: MessageCollectionViewCell) {}
+
+    func didTapMessageTrailingLabel(in cell: MessageCollectionViewCell) {}
 }

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -93,6 +93,16 @@ public protocol MessagesDataSource: AnyObject {
     /// The default value returned by this method is `nil`.
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
+    /// The attributed text to be used for cell's trailing label.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed by this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is `nil`.
+    func messageTrailingLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
+
 }
 
 public extension MessagesDataSource {
@@ -114,6 +124,10 @@ public extension MessagesDataSource {
     }
 
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        return nil
+    }
+
+    func messageTrailingLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         return nil
     }
 

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -81,6 +81,17 @@ public protocol MessagesLayoutDelegate: AnyObject {
     ///   The default value returned by this method is zero.
     func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
 
+    /// Specifies the width for the message bubble's trailing label.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed for this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// - Note:
+    ///   The default value returned by this method is zero.
+    func messageTrailingLabelWidth(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
+
 }
 
 public extension MessagesLayoutDelegate {
@@ -102,6 +113,10 @@ public extension MessagesLayoutDelegate {
     }
 
     func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 0
+    }
+
+    func messageTrailingLabelWidth(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         return 0
     }
 }

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -60,6 +60,13 @@ open class MessageContentCell: MessageCollectionViewCell {
         return label
     }()
 
+    /// The left label of the messageBubble
+    open var messageTrailingLabel: InsetLabel = {
+        let label = InsetLabel()
+        label.numberOfLines = 0
+        return label
+    }()
+
     /// The `MessageCellDelegate` for the cell.
     open weak var delegate: MessageCellDelegate?
 
@@ -78,6 +85,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         contentView.addSubview(messageTopLabel)
         contentView.addSubview(messageBottomLabel)
         contentView.addSubview(messageContainerView)
+        contentView.addSubview(messageTrailingLabel)
         contentView.addSubview(avatarView)
     }
 
@@ -86,6 +94,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         cellTopLabel.text = nil
         messageTopLabel.text = nil
         messageBottomLabel.text = nil
+        messageTrailingLabel.text = nil
     }
 
     // MARK: - Configuration
@@ -98,6 +107,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         layoutBottomLabel(with: attributes)
         layoutCellTopLabel(with: attributes)
         layoutMessageTopLabel(with: attributes)
+        layoutMessageTrailingLabel(with: attributes)
         layoutAvatarView(with: attributes)
     }
 
@@ -128,10 +138,12 @@ open class MessageContentCell: MessageCollectionViewCell {
         let topCellLabelText = dataSource.cellTopLabelAttributedText(for: message, at: indexPath)
         let topMessageLabelText = dataSource.messageTopLabelAttributedText(for: message, at: indexPath)
         let bottomText = dataSource.messageBottomLabelAttributedText(for: message, at: indexPath)
+        let trailingText = dataSource.messageTrailingLabelAttributedText(for: message, at: indexPath)
 
         cellTopLabel.attributedText = topCellLabelText
         messageTopLabel.attributedText = topMessageLabelText
         messageBottomLabel.attributedText = bottomText
+        messageTrailingLabel.attributedText = trailingText
     }
 
     /// Handle tap gesture on contentView and its subviews.
@@ -149,6 +161,8 @@ open class MessageContentCell: MessageCollectionViewCell {
             delegate?.didTapMessageTopLabel(in: self)
         case messageBottomLabel.frame.contains(touchLocation):
             delegate?.didTapMessageBottomLabel(in: self)
+        case messageTrailingLabel.frame.contains(touchLocation):
+            delegate?.didTapMessageTrailingLabel(in: self)
         default:
             break
         }
@@ -269,6 +283,41 @@ open class MessageContentCell: MessageCollectionViewCell {
         let origin = CGPoint(x: 0, y: y)
 
         messageBottomLabel.frame = CGRect(origin: origin, size: attributes.messageBottomLabelSize)
+    }
+
+    /// Positions the cell's left label.
+    /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
+    open func layoutMessageTrailingLabel(with attributes: MessagesCollectionViewLayoutAttributes) {
+        guard attributes.messageTrailingLabelSize != .zero else { return }
+
+        messageTrailingLabel.textAlignment = attributes.messageTrailingLabelAlignment.textAlignment
+
+        var origin: CGPoint = .zero
+        switch attributes.avatarPosition.horizontal {
+        case .cellLeading:
+            origin.x = messageContainerView.frame.maxX + attributes.messageContainerPadding.right
+        case .cellTrailing:
+            origin.x = messageContainerView.frame.minX - attributes.messageContainerPadding.left - attributes.messageTrailingLabelSize.width
+        case .natural:
+            fatalError(MessageKitError.avatarPositionUnresolved)
+        }
+
+        switch attributes.messageTrailingPosition.vertical {
+        case .messageLabelTop:
+            origin.y = messageTopLabel.frame.minY
+        case .messageTop: // Needs messageContainerView frame to be set
+            origin.y = messageContainerView.frame.minY
+        case .messageBottom: // Needs messageContainerView frame to be set
+            origin.y = messageContainerView.frame.maxY - attributes.messageTrailingLabelSize.height
+        case .messageCenter: // Needs messageContainerView frame to be set
+            origin.y = messageContainerView.frame.midY - (attributes.messageTrailingLabelSize.height/2)
+        case .cellBottom:
+            origin.y = attributes.frame.height - attributes.messageTrailingLabelSize.height
+        default:
+            break
+        }
+
+        messageTrailingLabel.frame = CGRect(origin: origin, size: attributes.messageTrailingLabelSize)
     }
     
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Add the message trailing label. This label is on the left side with the message from the sender and on the right side to receive messages.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


